### PR TITLE
Simple extensions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 next release
 ------------
 
+- Main extensions (``.js`` or ``.css``) can be omitted now in asset file names.
+  E.g., you can rename ``application.js.coffee`` asset to
+  ``application.coffee``.
+
 - Asset requirements are restricted by MIME type now, not by extension. E.g.,
   you can require Handlebars templates or JavaScript assets from CoffeeScript
   now.

--- a/gears/asset_attributes.py
+++ b/gears/asset_attributes.py
@@ -78,7 +78,8 @@ class AssetAttributes(object):
             >>> attrs.logical_path
             'js/models.js'
         """
-        return self.path_without_suffix + self.format_extension
+        format_extension = self.format_extension or self.compiler_format_extension
+        return self.path_without_suffix + format_extension
 
     @cached_property
     def extensions(self):
@@ -137,7 +138,12 @@ class AssetAttributes(object):
             >>> attrs.suffix
             ['.coffee']
         """
-        return [e for e in self.suffix[1:] if self.environment.compilers.get(e)]
+        try:
+            index = self.extensions.index(self.format_extension)
+        except ValueError:
+            index = 0
+        extensions = self.extensions[index:]
+        return [e for e in extensions if self.environment.compilers.get(e)]
 
     @cached_property
     def compilers(self):
@@ -170,4 +176,20 @@ class AssetAttributes(object):
     def mimetype(self):
         """MIME type of the asset."""
         return (self.environment.mimetypes.get(self.format_extension) or
-                'application/octet-stream')
+                self.compiler_mimetype or 'application/octet-stream')
+
+    @cached_property
+    def compiler_mimetype(self):
+        """Implicit MIME type of the asset by its compilers."""
+        for compiler in reversed(self.compilers):
+            if compiler.result_mimetype:
+                return compiler.result_mimetype
+        return None
+
+    @cached_property
+    def compiler_format_extension(self):
+        """Implicit format extension on the asset by its compilers."""
+        for extension, mimetype in self.environment.mimetypes.items():
+            if mimetype == self.compiler_mimetype:
+                return extension
+        return None

--- a/gears/environment.py
+++ b/gears/environment.py
@@ -179,7 +179,7 @@ class Suffixes(list):
     Every dictionary has three keys: ``extensions``, ``result_mimetype`` and
     ``mimetype``:
 
-    - ``extensions`` is a suffix as a list (e.g. ``['.js', '.coffee']``);
+    - ``suffix`` is a suffix as a list of extensions (e.g. ``['.js', '.coffee']``);
     - ``result_mimetype`` is a MIME type of a compiled asset with this suffix;
     - ``mimetype`` is a MIME type, for which this suffix is registered.
     """
@@ -187,34 +187,34 @@ class Suffixes(list):
     def register(self, extension, root=False, to=None, mimetype=None):
         if root:
             self.append({
-                'extensions': [extension],
+                'suffix': [extension],
                 'result_mimetype': mimetype,
                 'mimetype': mimetype,
             })
             return
         new = []
-        for suffix in self:
-            if to is not None and suffix['mimetype'] != to:
+        for item in self:
+            if to is not None and item['mimetype'] != to:
                 continue
-            extensions = list(suffix['extensions'])
+            extensions = list(item['suffix'])
             extensions.append(extension)
             new.append({
-                'extensions': extensions,
-                'result_mimetype': suffix['result_mimetype'],
+                'suffix': extensions,
+                'result_mimetype': item['result_mimetype'],
                 'mimetype': mimetype,
             })
         self.extend(new)
 
     def unregister(self, extension):
-        for suffix in list(self):
-            if extension in suffix['extensions']:
-                self.remove(suffix)
+        for item in list(self):
+            if extension in item['suffix']:
+                self.remove(item)
 
     def find(self, mimetype=None):
         suffixes = []
-        for suffix in self:
-            if mimetype is None or suffix['result_mimetype'] == mimetype:
-                suffixes.append(''.join(suffix['extensions']))
+        for item in self:
+            if mimetype is None or item['result_mimetype'] == mimetype:
+                suffixes.append(''.join(item['suffix']))
         return suffixes
 
 

--- a/gears/environment.py
+++ b/gears/environment.py
@@ -188,6 +188,7 @@ class Suffixes(list):
         if root:
             self.append({
                 'suffix': [extension],
+                'full': [extension],
                 'result_mimetype': mimetype,
                 'mimetype': mimetype,
             })
@@ -196,18 +197,28 @@ class Suffixes(list):
         for item in self:
             if to is not None and item['mimetype'] != to:
                 continue
-            extensions = list(item['suffix'])
-            extensions.append(extension)
+            suffix = list(item['suffix'])
+            suffix.append(extension)
+            full = list(item['full'])
+            full.append(extension)
             new.append({
-                'suffix': extensions,
+                'suffix': suffix,
+                'full': full,
                 'result_mimetype': item['result_mimetype'],
                 'mimetype': mimetype,
             })
+            if to is not None:
+                new.append({
+                    'suffix': [extension],
+                    'full': full,
+                    'result_mimetype': item['result_mimetype'],
+                    'mimetype': mimetype,
+                })
         self.extend(new)
 
     def unregister(self, extension):
         for item in list(self):
-            if extension in item['suffix']:
+            if extension in item['full']:
                 self.remove(item)
 
     def find(self, mimetype=None):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -51,8 +51,9 @@ class EnvironmentTests(TestCase):
         self.environment.mimetypes.register('.css', 'text/css')
         self.environment.mimetypes.register('.txt', 'text/plain')
         self.environment.compilers.register('.styl', FakeCompiler('text/css'))
-        self.assertItemsEqual(self.environment.suffixes.find(),
-                              ['.css', '.css.styl', '.txt'])
+        self.assertItemsEqual(self.environment.suffixes.find(), [
+            '.css', '.styl', '.css.styl', '.txt',
+        ])
 
     def test_register_defaults(self):
         self.environment.compilers = Mock()

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -9,30 +9,30 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
 
-    def test_register_root_extensions(self):
+    def test_register_root_suffix(self):
         self.assertItemsEqual(self.suffixes, [
-            {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
-            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'suffix': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
+            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
         ])
 
     def test_register_extension_to_mimetype(self):
         self.suffixes.register('.styl', to='text/css')
         self.assertItemsEqual(self.suffixes, [
-            {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
-            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-            {'extensions': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
+            {'suffix': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
+            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'suffix': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
         ])
 
     def test_register_extension_to_none(self):
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.assertItemsEqual(self.suffixes, [
-            {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
-            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-            {'extensions': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
-            {'extensions': ['.css', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
-            {'extensions': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
-            {'extensions': ['.css', '.styl', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
+            {'suffix': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
+            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'suffix': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
+            {'suffix': ['.css', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
+            {'suffix': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
+            {'suffix': ['.css', '.styl', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
         ])
 
     def test_unregister_extension(self):
@@ -40,8 +40,8 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.tmpl')
         self.suffixes.unregister('.css')
         self.assertItemsEqual(self.suffixes, [
-            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-            {'extensions': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
+            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'suffix': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
         ])
 
     def test_find_all(self):

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -6,18 +6,16 @@ class SuffixesTests(TestCase):
 
     def setUp(self):
         self.suffixes = Suffixes()
-
-    def test_register_root_extensions(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
+
+    def test_register_root_extensions(self):
         self.assertItemsEqual(self.suffixes, [
             {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
             {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
         ])
 
     def test_register_extension_to_mimetype(self):
-        self.suffixes.register('.css', root=True, mimetype='text/css')
-        self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.assertItemsEqual(self.suffixes, [
             {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
@@ -26,8 +24,6 @@ class SuffixesTests(TestCase):
         ])
 
     def test_register_extension_to_none(self):
-        self.suffixes.register('.css', root=True, mimetype='text/css')
-        self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.assertItemsEqual(self.suffixes, [
@@ -40,8 +36,6 @@ class SuffixesTests(TestCase):
         ])
 
     def test_unregister_extension(self):
-        self.suffixes.register('.css', root=True, mimetype='text/css')
-        self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.suffixes.unregister('.css')
@@ -51,14 +45,10 @@ class SuffixesTests(TestCase):
         ])
 
     def test_find_all(self):
-        self.suffixes.register('.css', root=True, mimetype='text/css')
-        self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.assertItemsEqual(self.suffixes.find(), ['.css', '.txt', '.css.styl'])
 
     def test_find_by_mimetype(self):
-        self.suffixes.register('.css', root=True, mimetype='text/css')
-        self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.assertItemsEqual(self.suffixes.find('text/css'), ['.css', '.css.styl'])
         self.assertItemsEqual(self.suffixes.find('text/plain'), ['.txt'])

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -10,7 +10,7 @@ class SuffixesTests(TestCase):
     def test_register_root_extensions(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
-        self.assertEqual(self.suffixes, [
+        self.assertItemsEqual(self.suffixes, [
             {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
             {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
         ])
@@ -19,7 +19,7 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
-        self.assertEqual(self.suffixes, [
+        self.assertItemsEqual(self.suffixes, [
             {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
             {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
             {'extensions': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
@@ -30,7 +30,7 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
-        self.assertEqual(self.suffixes, [
+        self.assertItemsEqual(self.suffixes, [
             {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
             {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
             {'extensions': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
@@ -45,7 +45,7 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.suffixes.unregister('.css')
-        self.assertEqual(self.suffixes, [
+        self.assertItemsEqual(self.suffixes, [
             {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
             {'extensions': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
         ])
@@ -54,14 +54,14 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
-        self.assertEqual(self.suffixes.find(), ['.css', '.txt', '.css.styl'])
+        self.assertItemsEqual(self.suffixes.find(), ['.css', '.txt', '.css.styl'])
 
     def test_find_by_mimetype(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
-        self.assertEqual(self.suffixes.find('text/css'), ['.css', '.css.styl'])
-        self.assertEqual(self.suffixes.find('text/plain'), ['.txt'])
+        self.assertItemsEqual(self.suffixes.find('text/css'), ['.css', '.css.styl'])
+        self.assertItemsEqual(self.suffixes.find('text/plain'), ['.txt'])
 
     def test_find_nothing(self):
-        self.assertEqual(self.suffixes.find('application/javascript'), [])
+        self.assertItemsEqual(self.suffixes.find('application/javascript'), [])

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -10,39 +10,74 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
 
     def test_register_root_suffix(self):
-        self.assertItemsEqual(self.suffixes, [
-            {'suffix': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
-            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-        ])
+        self.assertItemsEqual(self.suffixes, [{
+            'suffix': ['.css'],
+            'result_mimetype': 'text/css',
+            'mimetype': 'text/css',
+        }, {
+            'suffix': ['.txt'],
+            'result_mimetype': 'text/plain',
+            'mimetype': 'text/plain',
+        }])
 
     def test_register_extension_to_mimetype(self):
         self.suffixes.register('.styl', to='text/css')
-        self.assertItemsEqual(self.suffixes, [
-            {'suffix': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
-            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-            {'suffix': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
-        ])
+        self.assertItemsEqual(self.suffixes, [{
+            'suffix': ['.css'],
+            'result_mimetype': 'text/css',
+            'mimetype': 'text/css',
+        }, {
+            'suffix': ['.txt'],
+            'result_mimetype': 'text/plain',
+            'mimetype': 'text/plain',
+        }, {
+            'suffix': ['.css', '.styl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }])
 
     def test_register_extension_to_none(self):
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
-        self.assertItemsEqual(self.suffixes, [
-            {'suffix': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
-            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-            {'suffix': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
-            {'suffix': ['.css', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
-            {'suffix': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
-            {'suffix': ['.css', '.styl', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
-        ])
+        self.assertItemsEqual(self.suffixes, [{
+            'suffix': ['.css'],
+            'result_mimetype': 'text/css',
+            'mimetype': 'text/css',
+        }, {
+            'suffix': ['.txt'],
+            'result_mimetype': 'text/plain',
+            'mimetype': 'text/plain',
+        }, {
+            'suffix': ['.css', '.styl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }, {
+            'suffix': ['.css', '.tmpl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }, {
+            'suffix': ['.txt', '.tmpl'],
+            'result_mimetype': 'text/plain',
+            'mimetype': None,
+        }, {
+            'suffix': ['.css', '.styl', '.tmpl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }])
 
     def test_unregister_extension(self):
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.suffixes.unregister('.css')
-        self.assertItemsEqual(self.suffixes, [
-            {'suffix': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
-            {'suffix': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
-        ])
+        self.assertItemsEqual(self.suffixes, [{
+            'suffix': ['.txt'],
+            'result_mimetype': 'text/plain',
+            'mimetype': 'text/plain',
+        }, {
+            'suffix': ['.txt', '.tmpl'],
+            'result_mimetype': 'text/plain',
+            'mimetype': None,
+        }])
 
     def test_find_all(self):
         self.suffixes.register('.styl', to='text/css')

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -12,10 +12,12 @@ class SuffixesTests(TestCase):
     def test_register_root_suffix(self):
         self.assertItemsEqual(self.suffixes, [{
             'suffix': ['.css'],
+            'full': ['.css'],
             'result_mimetype': 'text/css',
             'mimetype': 'text/css',
         }, {
             'suffix': ['.txt'],
+            'full': ['.txt'],
             'result_mimetype': 'text/plain',
             'mimetype': 'text/plain',
         }])
@@ -24,14 +26,22 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.styl', to='text/css')
         self.assertItemsEqual(self.suffixes, [{
             'suffix': ['.css'],
+            'full': ['.css'],
             'result_mimetype': 'text/css',
             'mimetype': 'text/css',
         }, {
             'suffix': ['.txt'],
+            'full': ['.txt'],
             'result_mimetype': 'text/plain',
             'mimetype': 'text/plain',
         }, {
+            'suffix': ['.styl'],
+            'full': ['.css', '.styl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }, {
             'suffix': ['.css', '.styl'],
+            'full': ['.css', '.styl'],
             'result_mimetype': 'text/css',
             'mimetype': None,
         }])
@@ -41,26 +51,42 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.tmpl')
         self.assertItemsEqual(self.suffixes, [{
             'suffix': ['.css'],
+            'full': ['.css'],
             'result_mimetype': 'text/css',
             'mimetype': 'text/css',
         }, {
             'suffix': ['.txt'],
+            'full': ['.txt'],
             'result_mimetype': 'text/plain',
             'mimetype': 'text/plain',
         }, {
+            'suffix': ['.styl'],
+            'full': ['.css', '.styl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }, {
             'suffix': ['.css', '.styl'],
+            'full': ['.css', '.styl'],
             'result_mimetype': 'text/css',
             'mimetype': None,
         }, {
             'suffix': ['.css', '.tmpl'],
+            'full': ['.css', '.tmpl'],
             'result_mimetype': 'text/css',
             'mimetype': None,
         }, {
             'suffix': ['.txt', '.tmpl'],
+            'full': ['.txt', '.tmpl'],
             'result_mimetype': 'text/plain',
             'mimetype': None,
         }, {
+            'suffix': ['.styl', '.tmpl'],
+            'full': ['.css', '.styl', '.tmpl'],
+            'result_mimetype': 'text/css',
+            'mimetype': None,
+        }, {
             'suffix': ['.css', '.styl', '.tmpl'],
+            'full': ['.css', '.styl', '.tmpl'],
             'result_mimetype': 'text/css',
             'mimetype': None,
         }])
@@ -71,21 +97,23 @@ class SuffixesTests(TestCase):
         self.suffixes.unregister('.css')
         self.assertItemsEqual(self.suffixes, [{
             'suffix': ['.txt'],
+            'full': ['.txt'],
             'result_mimetype': 'text/plain',
             'mimetype': 'text/plain',
         }, {
             'suffix': ['.txt', '.tmpl'],
+            'full': ['.txt', '.tmpl'],
             'result_mimetype': 'text/plain',
             'mimetype': None,
         }])
 
     def test_find_all(self):
         self.suffixes.register('.styl', to='text/css')
-        self.assertItemsEqual(self.suffixes.find(), ['.css', '.txt', '.css.styl'])
+        self.assertItemsEqual(self.suffixes.find(), ['.css', '.txt', '.styl', '.css.styl'])
 
     def test_find_by_mimetype(self):
         self.suffixes.register('.styl', to='text/css')
-        self.assertItemsEqual(self.suffixes.find('text/css'), ['.css', '.css.styl'])
+        self.assertItemsEqual(self.suffixes.find('text/css'), ['.css', '.styl', '.css.styl'])
         self.assertItemsEqual(self.suffixes.find('text/plain'), ['.txt'])
 
     def test_find_nothing(self):


### PR DESCRIPTION
Allow to skip `.css` and `.js` extensions and to write just `.coffee` or `.styl` instead of `.js.coffee` and `.css.styl`. 
