### PR TITLE
Allow to require assets with the same MIME type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+next release
+------------
+
+- Asset requirements are restricted by MIME type now, not by extension. E.g.,
+  you can require Handlebars templates or JavaScript assets from CoffeeScript
+  now.
+
 0.2 (2012-02-18)
 ----------------
 

--- a/gears/environment.py
+++ b/gears/environment.py
@@ -176,15 +176,21 @@ class PublicAssets(list):
 
 class Suffixes(list):
     """The registry for asset suffixes. It acts like a list of dictionaries.
-    Every dictionary has two keys: ``extensions`` and ``mimetype``:
+    Every dictionary has three keys: ``extensions``, ``result_mimetype`` and
+    ``mimetype``:
 
     - ``extensions`` is a suffix as a list (e.g. ``['.js', '.coffee']``);
+    - ``result_mimetype`` is a MIME type of a compiled asset with this suffix;
     - ``mimetype`` is a MIME type, for which this suffix is registered.
     """
 
     def register(self, extension, root=False, to=None, mimetype=None):
         if root:
-            self.append({'extensions': [extension], 'mimetype': mimetype})
+            self.append({
+                'extensions': [extension],
+                'result_mimetype': mimetype,
+                'mimetype': mimetype,
+            })
             return
         new = []
         for suffix in self:
@@ -192,7 +198,11 @@ class Suffixes(list):
                 continue
             extensions = list(suffix['extensions'])
             extensions.append(extension)
-            new.append({'extensions': extensions, 'mimetype': mimetype})
+            new.append({
+                'extensions': extensions,
+                'result_mimetype': suffix['result_mimetype'],
+                'mimetype': mimetype,
+            })
         self.extend(new)
 
     def unregister(self, extension):

--- a/gears/environment.py
+++ b/gears/environment.py
@@ -210,11 +210,12 @@ class Suffixes(list):
             if extension in suffix['extensions']:
                 self.remove(suffix)
 
-    def find(self, *extensions):
-        extensions = list(extensions)
-        length = len(extensions)
-        return [''.join(suffix['extensions']) for suffix in self
-                if suffix['extensions'][:length] == extensions]
+    def find(self, mimetype=None):
+        suffixes = []
+        for suffix in self:
+            if mimetype is None or suffix['result_mimetype'] == mimetype:
+                suffixes.append(''.join(suffix['extensions']))
+        return suffixes
 
 
 class Environment(object):
@@ -315,7 +316,7 @@ class Environment(object):
         elif logical:
             asset_attribute = AssetAttributes(self, item)
             path = asset_attribute.path_without_suffix
-            for suffix in self.suffixes.find(*asset_attribute.suffix):
+            for suffix in self.suffixes.find(asset_attribute.mimetype):
                 try:
                     return self.find(path + suffix)
                 except FileNotFound:
@@ -329,29 +330,28 @@ class Environment(object):
                 return AssetAttributes(self, item), absolute_path
         raise FileNotFound(item)
 
-    def list(self, path, suffix=None):
+    def list(self, path, mimetype=None):
         """Yield two-tuples for all files found in the directory given by
         ``path`` parameter. Result can be filtered by the second parameter,
-        ``suffix``, that must be a list or tuple of file extensions. Each tuple
-        has :class:`~gears.asset_attributes.AssetAttributes` instance for found
-        file path as first item, and absolute path to this file as second item.
+        ``mimetype``, that must be a MIME type of assets compiled source code.
+        Each tuple has :class:`~gears.asset_attributes.AssetAttributes`
+        instance for found file path as first item, and absolute path to this
+        file as second item.
 
         Usage example::
 
             # Yield all files from 'js/templates' directory.
             environment.list('js/libs')
 
-            # Yield only files that are in 'js/templates' directory and match
-            # pattern '*.js.handlebars' or are compiled to files that match
-            # pattern.
-            environment.list('js/templates', suffix=('.js', '.handlebars'))
+            # Yield only files that are in 'js/templates' directory and have
+            # 'application/javascript' MIME type of compiled source code.
+            environment.list('js/templates', mimetype='application/javascript')
         """
         found = set()
-        suffixes = self.suffixes.find(*suffix)
         for finder in self.finders:
             for logical_path, absolute_path in finder.list(path):
                 asset_attributes = AssetAttributes(self, logical_path)
-                if ''.join(asset_attributes.suffix) not in suffixes:
+                if mimetype is not None and asset_attributes.mimetype != mimetype:
                     continue
                 if logical_path not in found:
                     yield asset_attributes, absolute_path

--- a/gears/processors/directives.py
+++ b/gears/processors/directives.py
@@ -36,7 +36,7 @@ class DirectivesProcessor(BaseProcessor):
 
     def process_require_directory_directive(self, path):
         path = self.get_relative_path(path, is_directory=True)
-        list = self.asset.attributes.environment.list(path, self.asset.attributes.suffix)
+        list = self.asset.attributes.environment.list(path, self.asset.attributes.mimetype)
         for asset_attributes, absolute_path in sorted(list, key=lambda x: x[0].path):
             self.asset.requirements.add(self.get_asset(asset_attributes, absolute_path))
             self.asset.dependencies.add(os.path.dirname(absolute_path))

--- a/tests/test_asset_attributes.py
+++ b/tests/test_asset_attributes.py
@@ -1,14 +1,24 @@
 from gears.asset_attributes import AssetAttributes
+from gears.compilers import BaseCompiler, CoffeeScriptCompiler, StylusCompiler
 from gears.environment import Environment
 
 from mock import Mock
 from unittest2 import TestCase
 
 
+class TemplateCompiler(BaseCompiler):
+
+    def __call__(self, asset):
+        pass
+
+
 class AssetAttributesTests(TestCase):
 
     def setUp(self):
         self.environment = Environment('assets')
+        self.coffee_script_compiler = CoffeeScriptCompiler.as_handler()
+        self.stylus_compiler = StylusCompiler.as_handler()
+        self.template_compiler = TemplateCompiler.as_handler()
 
     def create_attributes(self, path):
         return AssetAttributes(self.environment, path)
@@ -66,7 +76,7 @@ class AssetAttributesTests(TestCase):
     def test_format_extension(self):
         self.environment.mimetypes.register('.css', 'text/css')
         self.environment.mimetypes.register('.js', 'application/javascript')
-        self.environment.compilers.register('.coffee', Mock())
+        self.environment.compilers.register('.coffee', self.coffee_script_compiler)
 
         def check(path, expected_result):
             format_extension = self.create_attributes(path).format_extension
@@ -82,7 +92,7 @@ class AssetAttributesTests(TestCase):
     def test_suffix(self):
         self.environment.mimetypes.register('.css', 'text/css')
         self.environment.mimetypes.register('.js', 'application/javascript')
-        self.environment.compilers.register('.coffee', Mock())
+        self.environment.compilers.register('.coffee', self.coffee_script_compiler)
 
         def check(path, expected_result):
             suffix = self.create_attributes(path).suffix
@@ -97,8 +107,8 @@ class AssetAttributesTests(TestCase):
     def test_compiler_extensions(self):
         self.environment.mimetypes.register('.css', 'text/css')
         self.environment.mimetypes.register('.js', 'application/javascript')
-        self.environment.compilers.register('.coffee', Mock())
-        self.environment.compilers.register('.tmpl', Mock())
+        self.environment.compilers.register('.coffee', self.coffee_script_compiler)
+        self.environment.compilers.register('.tmpl', self.template_compiler)
 
         def check(path, expected_result):
             compiler_extensions = self.create_attributes(path).compiler_extensions
@@ -110,27 +120,25 @@ class AssetAttributesTests(TestCase):
         check('js/hot.coffee.js.tmpl', ['.tmpl'])
 
     def test_compilers(self):
-        coffee_compiler = Mock()
-        template_compiler = Mock()
         self.environment.mimetypes.register('.css', 'text/css')
         self.environment.mimetypes.register('.js', 'application/javascript')
-        self.environment.compilers.register('.coffee', coffee_compiler)
-        self.environment.compilers.register('.tmpl', template_compiler)
+        self.environment.compilers.register('.coffee', self.coffee_script_compiler)
+        self.environment.compilers.register('.tmpl', self.template_compiler)
 
         def check(path, expected_result):
             compilers = self.create_attributes(path).compilers
             self.assertEqual(compilers, expected_result)
 
         check('js/script.js', [])
-        check('js/script.js.coffee', [coffee_compiler])
-        check('js/script.js.coffee.tmpl', [coffee_compiler, template_compiler])
-        check('js/hot.coffee.js.tmpl', [template_compiler])
+        check('js/script.js.coffee', [self.coffee_script_compiler])
+        check('js/script.js.coffee.tmpl', [self.coffee_script_compiler, self.template_compiler])
+        check('js/hot.coffee.js.tmpl', [self.template_compiler])
 
     def test_mimetype(self):
         self.environment.mimetypes.register('.css', 'text/css')
         self.environment.mimetypes.register('.js', 'application/javascript')
-        self.environment.compilers.register('.coffee', Mock())
-        self.environment.compilers.register('.styl', Mock())
+        self.environment.compilers.register('.coffee', self.coffee_script_compiler)
+        self.environment.compilers.register('.styl', self.stylus_compiler)
 
         def check(path, expected_result):
             mimetype = self.create_attributes(path).mimetype

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -133,7 +133,7 @@ class EnvironmentListTests(TestCase):
         self.environment.finders.register(FileSystemFinder([ASSETS_DIR]))
 
     def test_list(self):
-        items = list(self.environment.list('js/templates', ['.js', '.handlebars']))
+        items = list(self.environment.list('js/templates', 'application/javascript'))
         self.assertEqual(len(items), 3)
         for i, item in enumerate(sorted(items, key=lambda x: x[1])):
             path = 'js/templates/%s.js.handlebars' % 'abc'[i]

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -10,34 +10,34 @@ class SuffixesTests(TestCase):
     def test_register_root_extensions(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
-        self.assertEqual(
-            self.suffixes,
-            [{'extensions': ['.css'], 'mimetype': 'text/css'},
-             {'extensions': ['.txt'], 'mimetype': 'text/plain'}])
+        self.assertEqual(self.suffixes, [
+            {'extensions': ['.css'], 'mimetype': 'text/css'},
+            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
+        ])
 
     def test_register_extension_to_mimetype(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
-        self.assertEqual(
-            self.suffixes,
-            [{'extensions': ['.css'], 'mimetype': 'text/css'},
-             {'extensions': ['.txt'], 'mimetype': 'text/plain'},
-             {'extensions': ['.css', '.styl'], 'mimetype': None}])
+        self.assertEqual(self.suffixes, [
+            {'extensions': ['.css'], 'mimetype': 'text/css'},
+            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
+            {'extensions': ['.css', '.styl'], 'mimetype': None},
+        ])
 
     def test_register_extension_to_none(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
-        self.assertEqual(
-            self.suffixes,
-            [{'extensions': ['.css'], 'mimetype': 'text/css'},
-             {'extensions': ['.txt'], 'mimetype': 'text/plain'},
-             {'extensions': ['.css', '.styl'], 'mimetype': None},
-             {'extensions': ['.css', '.tmpl'], 'mimetype': None},
-             {'extensions': ['.txt', '.tmpl'], 'mimetype': None},
-             {'extensions': ['.css', '.styl', '.tmpl'], 'mimetype': None}])
+        self.assertEqual(self.suffixes, [
+            {'extensions': ['.css'], 'mimetype': 'text/css'},
+            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
+            {'extensions': ['.css', '.styl'], 'mimetype': None},
+            {'extensions': ['.css', '.tmpl'], 'mimetype': None},
+            {'extensions': ['.txt', '.tmpl'], 'mimetype': None},
+            {'extensions': ['.css', '.styl', '.tmpl'], 'mimetype': None},
+        ])
 
     def test_unregister_extension(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
@@ -45,10 +45,10 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.suffixes.unregister('.css')
-        self.assertEqual(
-            self.suffixes,
-            [{'extensions': ['.txt'], 'mimetype': 'text/plain'},
-             {'extensions': ['.txt', '.tmpl'], 'mimetype': None}])
+        self.assertEqual(self.suffixes, [
+            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
+            {'extensions': ['.txt', '.tmpl'], 'mimetype': None},
+        ])
 
     def test_find_all(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -56,17 +56,12 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.styl', to='text/css')
         self.assertEqual(self.suffixes.find(), ['.css', '.txt', '.css.styl'])
 
-    def test_find_by_extension(self):
+    def test_find_by_mimetype(self):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
-        self.assertEqual(self.suffixes.find('.css'), ['.css', '.css.styl'])
-
-    def test_find_by_many_extensions(self):
-        self.suffixes.register('.css', root=True, mimetype='text/css')
-        self.suffixes.register('.txt', root=True, mimetype='text/plain')
-        self.suffixes.register('.styl', to='text/css')
-        self.assertEqual(self.suffixes.find('.css', '.styl'), ['.css.styl'])
+        self.assertEqual(self.suffixes.find('text/css'), ['.css', '.css.styl'])
+        self.assertEqual(self.suffixes.find('text/plain'), ['.txt'])
 
     def test_find_nothing(self):
-        self.assertEqual(self.suffixes.find('.css'), [])
+        self.assertEqual(self.suffixes.find('application/javascript'), [])

--- a/tests/test_environment_suffixes.py
+++ b/tests/test_environment_suffixes.py
@@ -11,8 +11,8 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.css', root=True, mimetype='text/css')
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.assertEqual(self.suffixes, [
-            {'extensions': ['.css'], 'mimetype': 'text/css'},
-            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
+            {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
+            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
         ])
 
     def test_register_extension_to_mimetype(self):
@@ -20,9 +20,9 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.txt', root=True, mimetype='text/plain')
         self.suffixes.register('.styl', to='text/css')
         self.assertEqual(self.suffixes, [
-            {'extensions': ['.css'], 'mimetype': 'text/css'},
-            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
-            {'extensions': ['.css', '.styl'], 'mimetype': None},
+            {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
+            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'extensions': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
         ])
 
     def test_register_extension_to_none(self):
@@ -31,12 +31,12 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.styl', to='text/css')
         self.suffixes.register('.tmpl')
         self.assertEqual(self.suffixes, [
-            {'extensions': ['.css'], 'mimetype': 'text/css'},
-            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
-            {'extensions': ['.css', '.styl'], 'mimetype': None},
-            {'extensions': ['.css', '.tmpl'], 'mimetype': None},
-            {'extensions': ['.txt', '.tmpl'], 'mimetype': None},
-            {'extensions': ['.css', '.styl', '.tmpl'], 'mimetype': None},
+            {'extensions': ['.css'], 'result_mimetype': 'text/css', 'mimetype': 'text/css'},
+            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'extensions': ['.css', '.styl'], 'result_mimetype': 'text/css', 'mimetype': None},
+            {'extensions': ['.css', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
+            {'extensions': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
+            {'extensions': ['.css', '.styl', '.tmpl'], 'result_mimetype': 'text/css', 'mimetype': None},
         ])
 
     def test_unregister_extension(self):
@@ -46,8 +46,8 @@ class SuffixesTests(TestCase):
         self.suffixes.register('.tmpl')
         self.suffixes.unregister('.css')
         self.assertEqual(self.suffixes, [
-            {'extensions': ['.txt'], 'mimetype': 'text/plain'},
-            {'extensions': ['.txt', '.tmpl'], 'mimetype': None},
+            {'extensions': ['.txt'], 'result_mimetype': 'text/plain', 'mimetype': 'text/plain'},
+            {'extensions': ['.txt', '.tmpl'], 'result_mimetype': 'text/plain', 'mimetype': None},
         ])
 
     def test_find_all(self):


### PR DESCRIPTION
Now you can only require assets with the same extensions or assets, which are "compiled" to the same extension. E.g., if you have an asset named `application.js.coffee`, you can only require assets with `.js.coffee` extension in it.

It is better to allow to require assets with the same MIME type.
