### PR TITLE
Add support for Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .tox/
 dist/
 docs/_build/
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
 install:
-  - pip install unittest2 mock nose --use-mirrors
+  - pip install mock nose --use-mirrors
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install unittest2py3k --use-mirrors; else pip install unittest2 --use-mirrors; fi
   - pip install . --use-mirrors
 script: nosetests

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,8 @@ Features
 
   New compilers can be also easily added.
 
+* Supports Python 3.
+
 Installation
 ------------
 

--- a/gears/asset_handler.py
+++ b/gears/asset_handler.py
@@ -58,7 +58,7 @@ class ExecMixin(object):
         output, errors = p.communicate(input=input.encode('utf-8'))
         if p.returncode != 0:
             raise AssetHandlerError(errors)
-        return output
+        return output.decode('utf-8')
 
     def get_process(self):
         """Returns :class:`subprocess.Popen` instance with args from

--- a/gears/asset_handler.py
+++ b/gears/asset_handler.py
@@ -58,7 +58,7 @@ class ExecMixin(object):
         output, errors = p.communicate(input=input.encode('utf-8'))
         if p.returncode != 0:
             raise AssetHandlerError(errors)
-        return output.decode('utf-8')
+        return output
 
     def get_process(self):
         """Returns :class:`subprocess.Popen` instance with args from

--- a/gears/assets.py
+++ b/gears/assets.py
@@ -1,11 +1,9 @@
-from __future__ import with_statement
-
 import codecs
 import hashlib
 import os
 
 from .asset_attributes import AssetAttributes
-from .utils import cached_property, unique
+from .utils import cached_property, unique, UnicodeMixin
 
 
 class CircularDependencyError(Exception):
@@ -169,7 +167,7 @@ class BaseAsset(object):
         return '<%s absolute_path=%s>' % (self.__class__.__name__, self.absolute_path)
 
 
-class Asset(BaseAsset):
+class Asset(UnicodeMixin, BaseAsset):
 
     def __init__(self, *args, **kwargs):
         super(Asset, self).__init__(*args, **kwargs)
@@ -186,9 +184,6 @@ class Asset(BaseAsset):
 
     def __unicode__(self):
         return self.compressed_source
-
-    def __str__(self):
-        return unicode(self).encode('utf-8')
 
     @property
     def cached_data(self):
@@ -213,7 +208,7 @@ class Asset(BaseAsset):
             bundled_source = self.cache.get(cache_key)
             if bundled_source is not None:
                 return bundled_source
-        bundled_source = u'\n'.join(r.processed_source for r in self.requirements)
+        bundled_source = '\n'.join(r.processed_source for r in self.requirements)
         self.cache.set(cache_key, bundled_source)
         return bundled_source
 

--- a/gears/cache.py
+++ b/gears/cache.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import hashlib
 import os
 try:
@@ -47,6 +45,6 @@ class FileBasedCache(object):
             return None
 
     def _get_filepath(self, key):
-        relpath = hashlib.sha1(key).hexdigest()
+        relpath = hashlib.sha1(key.encode('utf-8')).hexdigest()
         relpath = os.path.join(relpath[:2], relpath[2:4], relpath[4:])
         return os.path.join(self.root, relpath)

--- a/gears/compressors/cssmin.py
+++ b/gears/compressors/cssmin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 try:
     from cssmin import cssmin
     cssmin_available = True

--- a/gears/compressors/slimit.py
+++ b/gears/compressors/slimit.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 try:
     from slimit import minify
     slimit_available = True

--- a/gears/environment.py
+++ b/gears/environment.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 
 from .asset_attributes import AssetAttributes

--- a/gears/processors/directives.py
+++ b/gears/processors/directives.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+import sys
 
 from .base import BaseProcessor
 from ..asset_attributes import AssetAttributes
@@ -30,7 +31,10 @@ class DirectivesProcessor(BaseProcessor):
 
     def process_directives(self):
         for directive in self.directives:
-            args = shlex.split(directive.encode('utf-8'))
+            # shlex didn't support Unicode prior to 2.7.3
+            if sys.version_info < (2, 7, 3):
+                directive = directive.encode('utf-8')
+            args = shlex.split(directive)
             self.types[args[0]](*args[1:])
 
     def process_require_directive(self, path):

--- a/gears/utils.py
+++ b/gears/utils.py
@@ -1,5 +1,8 @@
 import os
 import re
+import sys
+
+from collections import Callable
 
 
 missing = object()
@@ -21,6 +24,16 @@ class cached_property(object):
             value = self.func(obj)
             obj.__dict__[self.__name__] = value
         return value
+
+
+class UnicodeMixin(object):
+    """Python 3 compatible __str__/__unicode__ support"""
+
+    def __str__(self):
+        val = self.__unicode__()
+        if sys.version_info < (3, 0):
+            val = val.encode('utf-8')
+        return val
 
 
 def safe_join(base, *paths):
@@ -52,8 +65,8 @@ def listdir(path, recursive=False):
 
 
 def get_condition_func(condition):
-    if callable(condition):
+    if isinstance(condition, Callable):
         return condition
-    if isinstance(condition, basestring):
+    if isinstance(condition, str):
         condition = re.compile(condition)
     return lambda path: condition.search(path)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7'],
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.2'],
 )

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,12 +1,10 @@
-from __future__ import with_statement
-
 import codecs
 import os
+import sys
 
 from gears.assets import CircularDependencyError, Asset
 from gears.environment import Environment
 from gears.finders import FileSystemFinder
-from gears.processors import DirectivesProcessor
 
 from unittest2 import TestCase
 
@@ -44,4 +42,9 @@ class AssetTests(TestCase):
 
     def test_unicode_support(self):
         output = read(os.path.join(FIXTURES_DIR, 'unicode_support', 'output.js'))
-        self.assertEqual(unicode(self.get_asset('unicode_support')), output)
+        asset = self.get_asset('unicode_support')
+        if sys.version_info < (3, 0):
+            asset_output = unicode(asset)
+        else:
+            asset_output = str(asset)
+        self.assertEqual(asset_output, output)

--- a/tests/test_directives_parser.py
+++ b/tests/test_directives_parser.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 from gears.directives_parser import DirectivesParser
 from unittest2 import TestCase

--- a/tests/test_directives_processor.py
+++ b/tests/test_directives_processor.py
@@ -1,8 +1,6 @@
-from __future__ import with_statement
-
 import os
 
-from gears.assets import Requirements, Asset
+from gears.assets import Asset
 from gears.compilers import BaseCompiler
 from gears.environment import Environment
 from gears.finders import FileSystemFinder

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 import shutil
 from contextlib import contextmanager

--- a/tests/test_exec_mixin.py
+++ b/tests/test_exec_mixin.py
@@ -13,7 +13,7 @@ class ExecMixinTests(TestCase):
     def test_returns_stdout_on_success(self, Popen):
         result = Mock()
         result.returncode = 0
-        result.communicate.return_value = ('output', '')
+        result.communicate.return_value = (b'output', b'')
         Popen.return_value = result
         self.assertEqual(Exec().run('input'), 'output')
 
@@ -21,7 +21,7 @@ class ExecMixinTests(TestCase):
     def test_raises_stderr_on_failure(self, Popen):
         result = Mock()
         result.returncode = 1
-        result.communicate.return_value = ('', 'error')
+        result.communicate.return_value = (b'', b'error')
         Popen.return_value = result
         with self.assertRaises(AssetHandlerError):
             Exec().run('input')

--- a/tests/test_exec_mixin.py
+++ b/tests/test_exec_mixin.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from gears.asset_handler import AssetHandlerError, ExecMixin
 from mock import patch, Mock
 from unittest2 import TestCase

--- a/tests/test_file_system_finder.py
+++ b/tests/test_file_system_finder.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 
 from gears.exceptions import ImproperlyConfigured, FileNotFound

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from gears.utils import safe_join
 from unittest2 import TestCase
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,25 @@
 [tox]
-envlist = py26,py27
+envlist = py26,py27,py32
 
 [testenv]
 deps =
-  unittest2
   mock
   nose
   coverage
 commands =
   nosetests --with-coverage --cover-package=gears --cover-erase --cover-html --cover-html-dir={envdir}/cover {posargs}
+
+[testenv:py26]
+deps =
+  unittest2
+  {[testenv]deps}
+
+[testenv:py27]
+deps =
+  unittest2
+  {[testenv]deps}
+
+[testenv:py32]
+deps =
+  unittest2py3k
+  {[testenv]deps}


### PR DESCRIPTION
Thanks to your clean and mostly forwards-compatible code it wasn't hard to make it support Python 3 in the same codebase. I have also cleaned it up from future imports (which are redundant since Python 2.5 support has been dropped) and some unused ones. Please review.

I also tested it with a simple asset package containing simple css/js, less, coffeescript, stylus and handlebars. Works well with corresponding asset handlers without any additional changes. uglifyjs and clean css didn't give any troubles either. So it would be great if you could update trove classifications of following packages:
https://github.com/gears/gears-handlebars
https://github.com/gears/gears-clean-css
https://github.com/gears/gears-uglifyjs
https://github.com/gears/gears-less
https://github.com/gears/gears-coffeescript
https://github.com/gears/gears-stylus

Unfortunately built-in support for cssmin and slimit doesn't work with Python 3 since they both don't support it yet. I might get my hands on cssmin soon but as long as they're not hard requirements (and there are substitutes that work) I think it's fine for them to fail.

Also gears-cli won't work due to dependency on watchdog which doesn't seem to be fully compatible yet. And obviously not much sense on trying to get gears-django with gears-flask work as Django and Flask aren't ready for prime time Python 3 yet.

My original intention was to use gears with Pyramid so I think there will be a compatible plugin for that soon.

Thanks and awaiting for your feedback.
