### PR TITLE
Add input context to exception message.

### DIFF
--- a/gears/asset_handler.py
+++ b/gears/asset_handler.py
@@ -57,6 +57,19 @@ class ExecMixin(object):
         p = self.get_process()
         output, errors = p.communicate(input=input.encode('utf-8'))
         if p.returncode != 0:
+            import re
+            match = re.search(r'on line (\d+):', errors)
+            if match:
+                errors += "\n"
+
+                line = int(match.group(1))
+                lines = input.split('\n')
+
+                for i in range(max(0, line-5), min(line+5, len(lines))):
+                    errors += "{}: {}\n".format(i, lines[i])
+
+                errors += "\n"
+
             raise AssetHandlerError(errors)
         return output.decode('utf-8')
 


### PR DESCRIPTION
This is a proof of concept for adding input context to compiler error messages. I don't know if this is the most general way to do this, but it would make debugging a lot easier if the input source was shown in context, instead of just a single line error like "Error: Parse error on line 72: Unexpected 'INDENT'".
