### PR TITLE
Fixed a wrong URL bug.

### DIFF
--- a/gears/processors/hexdigest_paths.py
+++ b/gears/processors/hexdigest_paths.py
@@ -40,4 +40,5 @@ class HexdigestPathsProcessor(BaseProcessor):
         except FileNotFound:
             return path
         self.asset.dependencies.add(asset.absolute_path)
-        return os.path.relpath(asset.hexdigest_path, self.current_dir)
+        relpath = str(os.path.relpath(asset.hexdigest_path, self.current_dir))
+        return relpath.encode('string-escape')

--- a/gears/processors/hexdigest_paths.py
+++ b/gears/processors/hexdigest_paths.py
@@ -3,6 +3,7 @@ import re
 from ..assets import build_asset
 from ..exceptions import FileNotFound
 from .base import BaseProcessor
+from ..compat import is_py3, is_py2
 
 
 URL_RE = re.compile(r"""url\((['"]?)\s*(.*?)\s*\1\)""")
@@ -41,4 +42,7 @@ class HexdigestPathsProcessor(BaseProcessor):
             return path
         self.asset.dependencies.add(asset.absolute_path)
         relpath = str(os.path.relpath(asset.hexdigest_path, self.current_dir))
-        return relpath.encode('string-escape')
+        if is_py2:
+            return relpath.encode('string-escape')
+        elif is_py3:
+            return relpath.encode('unicode-escape').decode()


### PR DESCRIPTION
By default, gears will generate a hash for all files in URL attribute in CSS files.
But bug appears when server run on Windows platform.
Here is the introduction to the bug:
Bug in file: https://github.com/gears/gears/blob/develop/gears/processors/hexdigest_paths.py#L43

``` python
    ....
    return os.path.relpath(asset.hexdigest_path, self.current_dir)
```

the function return a string(not raw string), it will output "\" with "\". So the browser get return like:

```
#something {
    background: url('..\images\logo.b27b3c7f0a92855c976a0fef707483d3169151c3.png');
}
```

and it will visit: `..imageslogo.b27b3c7f0a92855c976a0fef707483d3169151c3.png`.

To fix this bug, just convert **string** to **raw string**.
