### PR TITLE
Fix circular dependency bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 dist/
 docs/_build/
 __pycache__
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist/
 docs/_build/
 __pycache__
+.idea

--- a/gears/processors/directives.py
+++ b/gears/processors/directives.py
@@ -60,6 +60,9 @@ class DirectivesProcessor(BaseProcessor):
         path = self.get_relative_path(path)
         list = self.asset.attributes.environment.list(path, self.asset.attributes.mimetype)
         for asset_attributes, absolute_path in sorted(list, key=lambda x: x[0].path.split('/')):
+            if absolute_path == self.asset.absolute_path:
+                found = True
+                continue
             self.asset.requirements.add(self.get_asset(asset_attributes, absolute_path))
             self.asset.dependencies.add(os.path.dirname(absolute_path))
             found = True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(filename):
 
 setup(
     name='Gears',
-    version='0.7.3',
+    version='0.7.3-myoung8',
     license='ISC',
     description='Compiles and concatenates JavaScript and CSS assets.',
     long_description=read('README.rst'),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(filename):
 
 setup(
     name='Gears',
-    version='0.7.2',
+    version='0.7.3',
     license='ISC',
     description='Compiles and concatenates JavaScript and CSS assets.',
     long_description=read('README.rst'),

--- a/tests/fixtures/directives_processor/requirements_empty_tree/source.js
+++ b/tests/fixtures/directives_processor/requirements_empty_tree/source.js
@@ -1,0 +1,1 @@
+//= require_tree .

--- a/tests/test_directives_processor.py
+++ b/tests/test_directives_processor.py
@@ -67,3 +67,10 @@ class DirectivesProcessorTests(GearsTestCase):
         self.assertItemsEqual(asset.dependencies.to_list(), [
             os.path.join(os.path.dirname(asset.absolute_path), 'mixins/colors.less'),
         ])
+
+    def test_require_tree_dot_does_not_raise_circular_dependency_error(self):
+        asset = self.get_asset('requirements_empty_tree')
+        DirectivesProcessor.as_handler()(asset)
+        self.assertEqual(1, len(list(asset.requirements)))
+        self.assertEqual([], asset.requirements.before)
+        self.assertEqual([], asset.requirements.after)


### PR DESCRIPTION
@yumike please review

This fixes a bug in the `DirectivesProcessor` that would cause a `CircularDependencyError` to be raised
if you have a manifest that looks like this:

```
//= require_tree .
```
