### PR TITLE
Fix AttributeError on python 3.10+

### DIFF
--- a/gears/utils.py
+++ b/gears/utils.py
@@ -1,6 +1,11 @@
 import os
 import re
-from collections import Callable
+
+try:
+    # python 3.10+
+    from collections.abc import Callable
+except AttributeError:
+    from collections import Callable
 
 
 missing = object()


### PR DESCRIPTION
`Callable` has been moved to collections.abc